### PR TITLE
Limit RoleSessionName length to avoid API errors

### DIFF
--- a/src/actions/login.js
+++ b/src/actions/login.js
@@ -72,9 +72,13 @@ async function login() {
     /* authenticate with aws */
 
     console.log(`Authenticating into "${envName}" environment as "${role}"...`.yellow)
+
+    const timestamp = Date.now().toString();
+    const userInfo = `${os.userInfo().username}-${username}-${envName}-${role}`;
+
     const stsParams = {
         RoleArn: roleToAssumeArn,
-        RoleSessionName: `${os.userInfo().username}-${username}-${envName}-${role}-${Date.now()}`,
+        RoleSessionName: `${userInfo.slice(0, 64 - timestamp.length - 1)}-${timestamp}`,
         SerialNumber: AWSUtils.constructMfaArn(HubAccountId, username),
         TokenCode: mfaCode,
         DurationSeconds: duration * 3600,


### PR DESCRIPTION
Hi @iamarkadyt,
AWS Organizations suggest `OrganizationAccountAccessRole` as default role name, when calling STS endpoint to assume the role on other accounts the naming convention in aws-auth can reach RoleSessionName field limits of 64 characters.

In order to avoid this issue I propose to limit the first part of the field generation to ensure that the field name does not exceed the length limit.